### PR TITLE
missing `content` directive 

### DIFF
--- a/source/rst/about_py.md
+++ b/source/rst/about_py.md
@@ -12,7 +12,9 @@ single: python
 
 # About Python
 
-## Contents
+```{contents}
+:depth: 2
+```
 
 ```{epigraph}
 "Python has gotten sufficiently weapons grade that we don’t descend into R


### PR DESCRIPTION
Hi @mmcky ,

This PR fixes the issue that "contents" did not show the subtopics like below.
![Screen Shot 2020-09-08 at 10 25 50 pm](https://user-images.githubusercontent.com/44494439/92476474-5bbacc80-f222-11ea-82fe-6d2784804dad.png)

"Contents" should be able to show the subtopics like below: (Note: this example does not refer to the about python lecture )
![Screen Shot 2020-09-08 at 10 27 26 pm](https://user-images.githubusercontent.com/44494439/92476555-7f7e1280-f222-11ea-908d-837f9fab93ad.png)
