### PR TITLE
 missing 'r' in sentence in list

### DIFF
--- a/source/rst/getting_started.md
+++ b/source/rst/getting_started.md
@@ -126,7 +126,7 @@ Once you have installed Anaconda, you can start the Jupyter notebook.
 
 Either
 
-* search for Jupyter in your applications menu, o
+* search for Jupyter in your applications menu, or
 * open up a terminal and type `jupyter notebook`
     * > Windows users should substitute "Anaconda command prompt" for "terminal" in the previous line.
 

--- a/source/rst/getting_started.md
+++ b/source/rst/getting_started.md
@@ -20,7 +20,7 @@ single: Python
 
 In this lecture, you will learn how to
 
-1. get a Python environment up and runnin
+1. get a Python environment up and running
 1. execute simple Python commands
 1. run a sample program
 1. install the code libraries that underpin these lectures
@@ -139,7 +139,7 @@ If you use the second option, you will see something like this
 The output tells us the notebook is running at `http://localhost:8888/`
 
 * `localhost` is the name of the local machine
-* `8888` refers to [port number](https://en.wikipedia.org/wiki/Port_%28computer_networking%29) 8888 on your compute
+* `8888` refers to [port number](https://en.wikipedia.org/wiki/Port_%28computer_networking%29) 8888 on your computer
 
 Thus, the Jupyter kernel is listening for Python commands on port 8888 of our local machine.
 
@@ -196,10 +196,10 @@ This means that the effect of typing at the keyboard **depends on which mode you
 The two modes are
 
 1. Edit mode
-    * > Indicated by a green border around one cell, plus a blinking curso
+    * > Indicated by a green border around one cell, plus a blinking cursor
     * > Whatever you type appears as is in that cell
 1. Command mode
-    * > The green border is replaced by a grey (or grey and blue) borde
+    * > The green border is replaced by a grey (or grey and blue) border
     * > Keystrokes are interpreted as commands --- for example, typing > b>  adds a new cell below  the current one
 
 To switch to


### PR DESCRIPTION
Hi @mmcky , 
this PR fixes missing "r" in the list [in this lecture](https://5f55bb5f90670f42e45c4689--epic-agnesi-957267.netlify.app/getting_started.html#starting-the-jupyter-notebook)
Please see the first sentence below:
![Screen Shot 2020-09-14 at 4 30 18 pm](https://user-images.githubusercontent.com/44494439/93051292-95b72300-f6a7-11ea-8521-572d7393a33d.png)

In [web version](https://python-programming.quantecon.org/getting_started.html#Starting-the-Jupyter-Notebook), there is "r" like below.
![Screen Shot 2020-09-14 at 4 30 39 pm](https://user-images.githubusercontent.com/44494439/93051323-a1a2e500-f6a7-11ea-95ab-be4c14b6f9f5.png)
