### PR TITLE
monospaced_text_err

### DIFF
--- a/source/rst/functions.md
+++ b/source/rst/functions.md
@@ -250,8 +250,8 @@ Notes
 
 * We are passing the argument `U` as a string, which is why we write it as `'U'`.
 * Notice that equality is tested with the `==` syntax, not `=`.
-    * > For example, the statement `> a = 10`>  assigns the name `> a`>  to the value `> 10`> .
-    * > The expression `> a == 10`>  evaluates to either `> True`>  or `> False`> , depending on the value of `> a`> .
+    * > For example, the statement `> a = 10`  assigns the name `> a` to the value `> 10`.
+    * > The expression `> a == 10` evaluates to either `> True` or `> False`, depending on the value of `> a`.
 
 Now, there are several ways that we can simplify the code above.
 


### PR DESCRIPTION
Hi @mmcky ,
This PR fixes monospaced text error.
This error occurs in other lecture too. Especially, in the list.

[Here](https://5f5f3879598fe1455097dc6b--epic-agnesi-957267.netlify.app/functions.html#adding-conditions), monospaced text has redundant ">".
![Screen Shot 2020-09-14 at 10 46 07 pm](https://user-images.githubusercontent.com/44494439/93087562-155ee500-f6dc-11ea-9d08-070d8dd7bfaa.png)
