### PR TITLE
[numba] import jitclass from numba.experimental

### DIFF
--- a/lectures/numba.md
+++ b/lectures/numba.md
@@ -286,7 +286,8 @@ created in {doc}`this lecture <python_oop>`.
 To compile this class we use the `@jitclass` decorator:
 
 ```{code-cell} python3
-from numba import jitclass, float64
+from numba import float64
+from numba.experimental import jitclass
 ```
 
 Notice that we also imported something called `float64`.


### PR DESCRIPTION
This PR updates `jitclass` to import from `numba.experimental` which is required for `numba>=0.52`

fixes #40 