### PR TITLE
Remove menubar from plugins list

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -12,4 +12,3 @@ sphinx:
   config:
     html_theme: quantecon_book_theme
     html_static_path: ['_static']
-    html_theme_options:

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -13,4 +13,3 @@ sphinx:
     html_theme: quantecon_book_theme
     html_static_path: ['_static']
     html_theme_options:
-      plugins_list: ['../plugins/qe-menubar.js']


### PR DESCRIPTION
This removes the QuantEcon menubar script from being added to the builds.

The `banner.png` didn't come across with the new source as it was on the TOC page, replaced by `intro.md`.