### PR TITLE
add a redirect document for old index_toc page

### DIFF
--- a/lectures/index_toc.md
+++ b/lectures/index_toc.md
@@ -1,0 +1,3 @@
+```{only} html
+<meta http-equiv="Refresh" content="0; url=intro.html" />
+```


### PR DESCRIPTION
**Note:** this will currently issue build warning as `index_toc.md` isn't included in the `_toc.yml` but I don't want it to show up in the `toc`