### PR TITLE
[debugging] migrate code-block to literal with syntax highlighting

### DIFF
--- a/lectures/debugging.md
+++ b/lectures/debugging.md
@@ -121,13 +121,13 @@ plot_log()  # Call the function, generate plot
 
 But this time we type in the following cell block
 
-```{code-block} ipython
+```ipython
 %debug
 ```
 
 You should be dropped into a new prompt that looks something like this
 
-```{code-block} ipython
+```ipython
 ipdb>
 ```
 
@@ -138,7 +138,7 @@ Now we can investigate the value of our variables at this point in the program, 
 For example, here we simply type the name `ax` to see what's happening with
 this object:
 
-```{code-block} ipython
+```ipython
 ipdb> ax
 array([<matplotlib.axes.AxesSubplot object at 0x290f5d0>,
        <matplotlib.axes.AxesSubplot object at 0x2930810>], dtype=object)
@@ -150,7 +150,7 @@ problem.
 To find out what else you can do from inside `ipdb` (or `pdb`), use the
 online help
 
-```{code-block} ipython
+```ipython
 ipdb> h
 
 Documented commands (type help <topic>):
@@ -203,7 +203,7 @@ To investigate, it would be helpful if we could inspect variables like `x` durin
 
 To this end, we add a "break point" by inserting  `breakpoint()` inside the function code block
 
-```{code-block} python3
+```python3
 def plot_log():
     breakpoint()
     fig, ax = plt.subplots()
@@ -216,7 +216,7 @@ plot_log()
 
 Now let's run the script, and investigate via the debugger
 
-```{code-block} ipython
+```ipython
 > <ipython-input-6-a188074383b7>(6)plot_log()
 -> fig, ax = plt.subplots()
 (Pdb) n


### PR DESCRIPTION
This PR migrates non-executable code blocks to `syntax highlighted literals` from `code-block` items to improve compatibility with `sphinx-tojupyter`