### PR TITLE
Revert "migrate code-block to literal with syntax highlighting (#106)"

### DIFF
--- a/lectures/debugging.md
+++ b/lectures/debugging.md
@@ -121,13 +121,13 @@ plot_log()  # Call the function, generate plot
 
 But this time we type in the following cell block
 
-```ipython
+```{code-block} ipython
 %debug
 ```
 
 You should be dropped into a new prompt that looks something like this
 
-```ipython
+```{code-block} ipython
 ipdb>
 ```
 
@@ -138,7 +138,7 @@ Now we can investigate the value of our variables at this point in the program, 
 For example, here we simply type the name `ax` to see what's happening with
 this object:
 
-```ipython
+```{code-block} ipython
 ipdb> ax
 array([<matplotlib.axes.AxesSubplot object at 0x290f5d0>,
        <matplotlib.axes.AxesSubplot object at 0x2930810>], dtype=object)
@@ -150,7 +150,7 @@ problem.
 To find out what else you can do from inside `ipdb` (or `pdb`), use the
 online help
 
-```ipython
+```{code-block} ipython
 ipdb> h
 
 Documented commands (type help <topic>):
@@ -203,7 +203,7 @@ To investigate, it would be helpful if we could inspect variables like `x` durin
 
 To this end, we add a "break point" by inserting  `breakpoint()` inside the function code block
 
-```python3
+```{code-block} python3
 def plot_log():
     breakpoint()
     fig, ax = plt.subplots()
@@ -216,7 +216,7 @@ plot_log()
 
 Now let's run the script, and investigate via the debugger
 
-```ipython
+```{code-block} ipython
 > <ipython-input-6-a188074383b7>(6)plot_log()
 -> fig, ax = plt.subplots()
 (Pdb) n

--- a/lectures/debugging.md
+++ b/lectures/debugging.md
@@ -122,14 +122,14 @@ plot_log()  # Call the function, generate plot
 But this time we type in the following cell block
 
 ```{code-block} ipython
-:no-execute:
+:class: no-execute
 %debug
 ```
 
 You should be dropped into a new prompt that looks something like this
 
 ```{code-block} ipython
-:no-execute:
+:class: no-execute
 ipdb>
 ```
 
@@ -141,7 +141,7 @@ For example, here we simply type the name `ax` to see what's happening with
 this object:
 
 ```{code-block} ipython
-:no-execute:
+:class: no-execute
 ipdb> ax
 array([<matplotlib.axes.AxesSubplot object at 0x290f5d0>,
        <matplotlib.axes.AxesSubplot object at 0x2930810>], dtype=object)
@@ -154,7 +154,7 @@ To find out what else you can do from inside `ipdb` (or `pdb`), use the
 online help
 
 ```{code-block} ipython
-:no-execute:
+:class: no-execute
 ipdb> h
 
 Documented commands (type help <topic>):
@@ -208,7 +208,7 @@ To investigate, it would be helpful if we could inspect variables like `x` durin
 To this end, we add a "break point" by inserting  `breakpoint()` inside the function code block
 
 ```{code-block} python3
-:no-execute:
+:class: no-execute
 def plot_log():
     breakpoint()
     fig, ax = plt.subplots()
@@ -222,7 +222,7 @@ plot_log()
 Now let's run the script, and investigate via the debugger
 
 ```{code-block} ipython
-:no-execute:
+:class: no-execute
 > <ipython-input-6-a188074383b7>(6)plot_log()
 -> fig, ax = plt.subplots()
 (Pdb) n

--- a/lectures/debugging.md
+++ b/lectures/debugging.md
@@ -122,12 +122,14 @@ plot_log()  # Call the function, generate plot
 But this time we type in the following cell block
 
 ```{code-block} ipython
+:no-execute:
 %debug
 ```
 
 You should be dropped into a new prompt that looks something like this
 
 ```{code-block} ipython
+:no-execute:
 ipdb>
 ```
 
@@ -139,6 +141,7 @@ For example, here we simply type the name `ax` to see what's happening with
 this object:
 
 ```{code-block} ipython
+:no-execute:
 ipdb> ax
 array([<matplotlib.axes.AxesSubplot object at 0x290f5d0>,
        <matplotlib.axes.AxesSubplot object at 0x2930810>], dtype=object)
@@ -151,6 +154,7 @@ To find out what else you can do from inside `ipdb` (or `pdb`), use the
 online help
 
 ```{code-block} ipython
+:no-execute:
 ipdb> h
 
 Documented commands (type help <topic>):
@@ -204,6 +208,7 @@ To investigate, it would be helpful if we could inspect variables like `x` durin
 To this end, we add a "break point" by inserting  `breakpoint()` inside the function code block
 
 ```{code-block} python3
+:no-execute:
 def plot_log():
     breakpoint()
     fig, ax = plt.subplots()
@@ -217,6 +222,7 @@ plot_log()
 Now let's run the script, and investigate via the debugger
 
 ```{code-block} ipython
+:no-execute:
 > <ipython-input-6-a188074383b7>(6)plot_log()
 -> fig, ax = plt.subplots()
 (Pdb) n


### PR DESCRIPTION
This reverts commit 58770817961938ddff4a4cfaee9e6f50d2985f19.