### PR TITLE
👌 NEW: Added nb_repo_url config

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -21,6 +21,7 @@ sphinx:
       header_organisation_url: https://quantecon.org
       header_organisation: QuantEcon
       repository_url: https://github.com/QuantEcon/lecture-python-programming.myst
+      nb_repository_url: https://github.com/QuantEcon/lecture-python-programming.notebooks
       twitter: quantecon
       twitter_logo_url: https://assets.quantecon.org/img/qe-twitter-logo.png
       og_logo_url: https://assets.quantecon.org/img/qe-og-logo.png


### PR DESCRIPTION
A new config variable called `nb_repository_url` is added, which stores the notebook repo url for the source files.

The implementation of which is in this PR https://github.com/QuantEcon/quantecon-book-theme/pull/71/files