### PR TITLE
[numba]_fix_imports

### DIFF
--- a/lectures/numba.md
+++ b/lectures/numba.md
@@ -286,8 +286,7 @@ created in {doc}`this lecture <python_oop>`.
 To compile this class we use the `@jitclass` decorator:
 
 ```{code-cell} python3
-from numba import float64
-from numba.experimental import jitclass
+from numba import float64, jitclass
 ```
 
 Notice that we also imported something called `float64`.


### PR DESCRIPTION
Good morning, @jstac and @mmcky ,

I noticed an issue in lecture [numba](https://python-programming.quantecon.org/numba.html#compiling-classes):
- the import ``from numba.experimental import jitclass`` is not working 
- it returns an error message ``ModuleNotFoundError: No module named 'numba.experimental'``

This PR fixes this issue by replacing
- the original imports ``from numba import float64`` and ``from numba.experimental import jitclass``
- with modified imports ``from numba import float64, jitclass``

Do you think it is a good idea?