### PR TITLE
[MAINT] move from using master to pip installs

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,6 @@ dependencies:
     - jupyter-book
     - sphinxext-rediraffe
     - sphinx-multitoc-numbering
-    - sphinx-exercise
     - joblib
     - interpolation
     - sphinx-tojupyter

--- a/environment.yml
+++ b/environment.yml
@@ -6,12 +6,12 @@ dependencies:
   - anaconda=2020.07
   - pip
   - pip:
-    - git+https://github.com/executablebooks/jupyter-book.git
+    - jupyter-book
     - sphinxext-rediraffe
-    - git+https://github.com/executablebooks/sphinx-multitoc-numbering
-    - git+https://github.com/executablebooks/sphinx-exercise.git
+    - sphinx-multitoc-numbering
+    - sphinx-exercise
     - joblib
     - interpolation
-    - git+https://github.com/QuantEcon/sphinx-tojupyter.git
-    - git+https://github.com/QuantEcon/quantecon-book-theme.git
+    - sphinx-tojupyter
+    - quantecon-book-theme
 

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -12,7 +12,7 @@ html:
   baseurl: https://python.quantecon.org/
 
 sphinx:
-  extra_extensions: [sphinx_multitoc_numbering, sphinx_exercise, sphinxext.rediraffe, sphinx_tojupyter]
+  extra_extensions: [sphinx_multitoc_numbering, sphinxext.rediraffe, sphinx_tojupyter]
   config:
     html_favicon: _static/lectures-favicon.ico
     html_theme: quantecon_book_theme


### PR DESCRIPTION
This PR migrates from using `master` branch versions to pip install for publishing stability