### PR TITLE
[python_oop] typo

### DIFF
--- a/lectures/numba.md
+++ b/lectures/numba.md
@@ -555,7 +555,7 @@ Now let's see how fast it runs:
 %time calculate_pi()
 ```
 
-If we switch of JIT compilation by removing `@njit`, the code takes around
+If we switch off JIT compilation by removing `@njit`, the code takes around
 150 times as long on our machine.
 
 So we get a speed gain of 2 orders of magnitude--which is huge--by adding four

--- a/lectures/numba.md
+++ b/lectures/numba.md
@@ -555,7 +555,7 @@ Now let's see how fast it runs:
 %time calculate_pi()
 ```
 
-If we switch off JIT compilation by removing `@njit`, the code takes around
+If we switch of JIT compilation by removing `@njit`, the code takes around
 150 times as long on our machine.
 
 So we get a speed gain of 2 orders of magnitude--which is huge--by adding four

--- a/lectures/python_oop.md
+++ b/lectures/python_oop.md
@@ -254,7 +254,7 @@ We'll also discuss the role of the peculiar  `self` bookkeeping device in detail
 
 #### Usage
 
-Here's an example in which we use the class `Consumer` to crdate an instance of a consumer whom we affectionately name $c1$.
+Here's an example in which we use the class `Consumer` to create an instance of a consumer whom we affectionately name $c1$.
 
 After we create consumer $c1$ and endow it with initial wealth $10$, we'll apply the `spend` method.
 


### PR DESCRIPTION
Hi @jstac @shlff , this PR corrects a typo in https://python-programming.quantecon.org/python_oop.html
crdate -> create