### PR TITLE
ENH: add execution statistics

### DIFF
--- a/lectures/_toc.yml
+++ b/lectures/_toc.yml
@@ -32,3 +32,4 @@
 - part: Other
   chapters:
     - file: troubleshooting
+    - file: status

--- a/lectures/status.md
+++ b/lectures/status.md
@@ -1,0 +1,9 @@
+# Execution Statistics
+
+This table contains the latest execution statistics.
+
+```{nb-exec-table}
+```
+
+These lectures are built on `linux` instances through `github actions` so are
+executed using the following [hardware specifications](https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources)

--- a/lectures/status.md
+++ b/lectures/status.md
@@ -1,3 +1,14 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
 # Execution Statistics
 
 This table contains the latest execution statistics.


### PR DESCRIPTION
This PR adds a `status` page to display execution statistics from `jupyter-cache`