### PR TITLE
FIX: update environment for quantecon

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,4 +15,6 @@ dependencies:
     - jupytext
     - ghp-import
     - jupinx
+    # Temporary Fixes
+    - tornado>=6.1
 


### PR DESCRIPTION
This is a maintenance update to our software environment due to an issue with `nbdime` -> `jupyter_server` not updating `tornado` to a compatible version. 