### PR TITLE
[mathjax] load the svg js from mathjax cdn

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -36,6 +36,7 @@ sphinx:
         notebook_interface        : classic  # The interface interactive links will activate ["classic", "jupyterlab"]
         binderhub_url             : https://mybinder.org  # The URL of the BinderHub (e.g., https://mybinder.org)
         thebe                     : false  # Add a thebe button to pages (requires the repository to run on Binder)
+    mathjax_path: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-svg.js
     rediraffe_redirects:
       index_toc.md: intro.md
     tojupyter_static_file_path: ["source/_static", "_static"]


### PR DESCRIPTION
Add specific mathjax script for loading `svg` from `mathml` and `tex`