### PR TITLE
[GA] Run Execution Checks on Schedule

### DIFF
--- a/.github/workflows/execution.yml
+++ b/.github/workflows/execution.yml
@@ -1,8 +1,8 @@
 name: Run Execution Tests [Latest Anaconda]
-on: push
-  # schedule:
-  #   # UTC 22:00 is early morning in Australia
-  #   - cron:  '0 22 * * *'
+on:
+  schedule:
+    # UTC 22:00 is early morning in Australia
+    - cron:  '0 22 * * *'
 jobs:
   execution-tests-linux-osx:
     name: Execution Tests (${{ matrix.python-version }}, ${{ matrix.os }})

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,8 +1,8 @@
 name: Run Execution Tests [Latest Anaconda]
-on: [push]
-  schedule:
-    # UTC 22:00 is early morning in Australia
-    - cron:  '0 22 * * *'
+on: push
+  # schedule:
+  #   # UTC 22:00 is early morning in Australia
+  #   - cron:  '0 22 * * *'
 jobs:
   execution-tests-linux-osx:
     name: Execution Tests (${{ matrix.python-version }}, ${{ matrix.os }})

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -23,7 +23,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install anaconda
-          pip install jupyter-book sphinx-multitoc-numbering quantecon-book-theme sphinxext-rediraffe
+          pip install jupyter-book sphinx-multitoc-numbering quantecon-book-theme sphinxext-rediraffe sphinx_tojupyter
       - name: Build Lectures (+ Execution Checks) [Linux, OS X]
         shell: bash -l {0}
         run: jb build lectures --path-output=./
@@ -47,7 +47,7 @@ jobs:
         run: |
           conda install anaconda
           pip install jupyter-book
-          pip install jupyter-book sphinx-multitoc-numbering quantecon-book-theme sphinxext-rediraffe
+          pip install jupyter-book sphinx-multitoc-numbering quantecon-book-theme sphinxext-rediraffe sphinx_tojupyter
       - name: Build Lectures (+ Execution Checks) [Windows]
         shell: powershell
         run: jb build lectures --path-output=./

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -26,7 +26,7 @@ jobs:
           pip install jupyter-book sphinx-multitoc-numbering quantecon-book-theme sphinxext-rediraffe sphinx_tojupyter
       - name: Build Lectures (+ Execution Checks) [Linux, OS X]
         shell: bash -l {0}
-        run: jb build lectures --path-output=./
+        run: jb build lectures --path-output=./ -W --keep-going
   execution-tests-win:
     name: Execution Tests (${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -50,4 +50,4 @@ jobs:
           pip install jupyter-book sphinx-multitoc-numbering quantecon-book-theme sphinxext-rediraffe sphinx_tojupyter
       - name: Build Lectures (+ Execution Checks) [Windows]
         shell: powershell
-        run: jb build lectures --path-output=./
+        run: jb build lectures --path-output=./ -W --keep-going

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,40 @@
+name: Run Execution Tests [Latest Anaconda]
+on:
+  pull_request:
+    types: [opened]
+  schedule:
+    # UTC 22:00 is early morning in Australia
+    - cron:  '0 22 * * *'
+jobs:
+  execution-tests:
+    name: Execution Tests (${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.8"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+      - name: Install Anaconda + Dependencies [Linux,OS X]
+        shell: bash -l {0}
+        run: |
+          conda install anaconda
+          pip install jupyter-book sphinx-multitoc-numbering quantecon-book-theme sphinxext-rediraffe
+      - name: Install Anaconda + Dependencies [Windows]
+        shell: pwsh
+        run: |
+          conda install anaconda
+          pip install jupyter-book
+          pip install jupyter-book sphinx-multitoc-numbering quantecon-book-theme sphinxext-rediraffe
+      - name: Build Lectures (+ Execution Checks) [Linux, OS X]
+        shell: bash -l {0}
+        run: jb build lectures --path-output=./
+      - name: Build Lectures (+ Execution Checks) [Windows]
+        shell: pwsh
+        run: jb build lectures --path-output=./

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -19,14 +19,20 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
-      - name: Install Anaconda + Dependencies [Linux,OS X]
+      - name: Install Anaconda + Dependencies
         shell: bash -l {0}
         run: |
           conda install anaconda
           pip install jupyter-book sphinx-multitoc-numbering quantecon-book-theme sphinxext-rediraffe sphinx_tojupyter
-      - name: Build Lectures (+ Execution Checks) [Linux, OS X]
+      - name: Build Lectures (+ Execution Checks)
         shell: bash -l {0}
         run: jb build lectures --path-output=./ -W --keep-going
+      - name: Upload Execution Reports
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: execution-reports
+          path: _build/html/reports
   execution-tests-win:
     name: Execution Tests (${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -42,12 +48,18 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
-      - name: Install Anaconda + Dependencies [Windows]
+      - name: Install Anaconda + Dependencies
         shell: powershell
         run: |
           conda install anaconda
           pip install jupyter-book
           pip install jupyter-book sphinx-multitoc-numbering quantecon-book-theme sphinxext-rediraffe sphinx_tojupyter
-      - name: Build Lectures (+ Execution Checks) [Windows]
+      - name: Build Lectures (+ Execution Checks)
         shell: powershell
         run: jb build lectures --path-output=./ -W --keep-going
+      - name: Upload Execution Reports
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: execution-reports
+          path: _build/html/reports

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,7 +1,7 @@
 name: Run Execution Tests [Latest Anaconda]
 on:
   pull_request:
-    types: [opened]
+    types: [push]
   schedule:
     # UTC 22:00 is early morning in Australia
     - cron:  '0 22 * * *'

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -6,13 +6,13 @@ on:
     # UTC 22:00 is early morning in Australia
     - cron:  '0 22 * * *'
 jobs:
-  execution-tests:
+  execution-tests-linux-osx:
     name: Execution Tests (${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-latest"]
         python-version: ["3.8"]
     steps:
       - name: Checkout
@@ -26,15 +26,30 @@ jobs:
         run: |
           conda install anaconda
           pip install jupyter-book sphinx-multitoc-numbering quantecon-book-theme sphinxext-rediraffe
+      - name: Build Lectures (+ Execution Checks) [Linux, OS X]
+        shell: bash -l {0}
+        run: jb build lectures --path-output=./
+  execution-tests-win:
+    name: Execution Tests (${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["windows-latest"]
+        python-version: ["3.8"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
       - name: Install Anaconda + Dependencies [Windows]
-        shell: pwsh
+        shell: powershell
         run: |
           conda install anaconda
           pip install jupyter-book
           pip install jupyter-book sphinx-multitoc-numbering quantecon-book-theme sphinxext-rediraffe
-      - name: Build Lectures (+ Execution Checks) [Linux, OS X]
-        shell: bash -l {0}
-        run: jb build lectures --path-output=./
       - name: Build Lectures (+ Execution Checks) [Windows]
-        shell: pwsh
+        shell: powershell
         run: jb build lectures --path-output=./

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,7 +1,5 @@
 name: Run Execution Tests [Latest Anaconda]
-on:
-  pull_request:
-    types: [push]
+on: [push]
   schedule:
     # UTC 22:00 is early morning in Australia
     - cron:  '0 22 * * *'

--- a/lectures/pandas.md
+++ b/lectures/pandas.md
@@ -549,7 +549,7 @@ Following the work you did in {ref}`Exercise 1 <pd_ex1>`, you can query the data
 ```{code-cell} python3
 indices_data = read_data(
         indices_list,
-        start=dt.datetime(1928, 1, 2),
+        start=dt.datetime(1971, 1, 1),  #Common Start Date
         end=dt.datetime(2020, 12, 31)
 )
 ```


### PR DESCRIPTION
This PR adds scheduled github actions to check for execution in `latest` anaconda on `windows, linux, and macos`

- [x] adds a fix for `windows` for an issue using `yfinance` on windows with dateranges