### PR TITLE
MAINT: Upgrade jupyter-book and quantecon-book-theme

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,8 +6,8 @@ dependencies:
   - anaconda=2021.05
   - pip
   - pip:
-    - jupyter-book==0.12.0
-    - quantecon-book-theme==0.2.7
+    - jupyter-book==0.12.1
+    - quantecon-book-theme==0.3.0
     - sphinx-tojupyter==0.2.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==0.2.1


### PR DESCRIPTION
This PR upgrades to `jupyter-book==0.12.1` which will bring improvements to `pdf` via `LaTeX`, and upgrade to the theme for bug fixes. 