### PR TITLE
MAINT: Set execution tests by platform at different times

### DIFF
--- a/.github/workflows/execution-linux.yml
+++ b/.github/workflows/execution-linux.yml
@@ -1,0 +1,35 @@
+name: Execution Tests [Latest Anaconda, Linux]
+on:
+  schedule:
+    # UTC 15:00 is early morning in Australia
+    - cron:  '0 15 * * *'
+jobs:
+  execution-tests-linux:
+    name: Execution Tests (${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.8"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+      - name: Install Anaconda + Dependencies
+        shell: bash -l {0}
+        run: |
+          conda install anaconda
+          pip install jupyter-book sphinx-multitoc-numbering quantecon-book-theme sphinxext-rediraffe sphinx_tojupyter
+      - name: Build Lectures (+ Execution Checks)
+        shell: bash -l {0}
+        run: jb build lectures --path-output=./ -W --keep-going
+      - name: Upload Execution Reports
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: execution-reports
+          path: _build/html/reports

--- a/.github/workflows/execution-osx.yml
+++ b/.github/workflows/execution-osx.yml
@@ -1,0 +1,35 @@
+name: Execution Tests [Latest Anaconda, OSX]
+on:
+  schedule:
+    # UTC 16:00 is early morning in Australia
+    - cron:  '0 16 * * *'
+jobs:
+  execution-tests-osx:
+    name: Execution Tests (${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["macos-latest"]
+        python-version: ["3.8"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+      - name: Install Anaconda + Dependencies
+        shell: bash -l {0}
+        run: |
+          conda install anaconda
+          pip install jupyter-book sphinx-multitoc-numbering quantecon-book-theme sphinxext-rediraffe sphinx_tojupyter
+      - name: Build Lectures (+ Execution Checks)
+        shell: bash -l {0}
+        run: jb build lectures --path-output=./ -W --keep-going
+      - name: Upload Execution Reports
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: execution-reports
+          path: _build/html/reports

--- a/.github/workflows/execution-win.yml
+++ b/.github/workflows/execution-win.yml
@@ -1,38 +1,9 @@
-name: Run Execution Tests [Latest Anaconda]
+name: Execution Tests [Latest Anaconda, Windows]
 on:
   schedule:
-    # UTC 22:00 is early morning in Australia
-    - cron:  '0 22 * * *'
+    # UTC 17:00 is early morning in Australia
+    - cron:  '0 17 * * *'
 jobs:
-  execution-tests-linux-osx:
-    name: Execution Tests (${{ matrix.python-version }}, ${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.8"]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
-      - name: Install Anaconda + Dependencies
-        shell: bash -l {0}
-        run: |
-          conda install anaconda
-          pip install jupyter-book sphinx-multitoc-numbering quantecon-book-theme sphinxext-rediraffe sphinx_tojupyter
-      - name: Build Lectures (+ Execution Checks)
-        shell: bash -l {0}
-        run: jb build lectures --path-output=./ -W --keep-going
-      - name: Upload Execution Reports
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: execution-reports
-          path: _build/html/reports
   execution-tests-win:
     name: Execution Tests (${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This PR sets the `nightly` execution tests to be run at different times for different platforms to save issues with `pandas` api calls getting limited by a data service. 