### PR TITLE
MAINT: Enable a base binder environment for thebe

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -1,0 +1,7 @@
+name: lecture-python-programming
+channels:
+  - default
+dependencies:
+  - python=3.8
+  - anaconda
+


### PR DESCRIPTION
This PR enables the same `environment.yml` in `.binder` as the notebook repository. 