### PR TITLE
Fix Missing Values in Pandas Lecture

### DIFF
--- a/lectures/pandas.md
+++ b/lectures/pandas.md
@@ -695,6 +695,10 @@ def read_data(ticker_list,
     for tick in ticker_list:
         stock = yf.Ticker(tick)
         prices = stock.history(start=start, end=end)
+
+        # Change the index to date
+        prices.index = pd.to_datetime(prices.index.date)
+        
         closing_prices = prices['Close']
         ticker[tick] = closing_prices
 


### PR DESCRIPTION
Hi @mmcky,

This PR resolves #246. The issue is quite trivial and hidden in the `for` loop. It seems that `yfinance` changed to date + time index and the Japanese market has different closing times from the US market, which leads to inconsistency in the index.

After updating the index to only dates, the issue is resolved.

Could you please kindly review the change and merge it if it looks good to you?

Many thanks!