### PR TITLE
ENH: use quantecon custom docker

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -27,43 +27,18 @@ jobs:
     needs: deploy-runner
     runs-on: [self-hosted, cml-gpu]
     container:
-      image: docker://nvidia/cuda:11.2.1-devel-ubuntu20.04
+      image: docker://mmcky/quantecon-lecture-python:py39-anaconda-2022-10
       options: --gpus all
     steps:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      # Install LaTeX (Support for matplotlib)
-      - name: Install latex dependencies
-        shell: bash -l {0}
-        run: |
-          apt-get -qq update
-          export DEBIAN_FRONTEND=noninteractive
-          apt-get install -y tzdata
-          apt-get install -y     \
-            texlive-latex-recommended \
-            texlive-latex-extra       \
-            texlive-fonts-recommended \
-            texlive-fonts-extra       \
-            texlive-xetex             \
-            latexmk                   \
-            xindy                     \
-            dvipng                    \
-            ghostscript               \
-            cm-super
-      - name: Setup Anaconda
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          auto-activate-base: true
-          miniconda-version: 'latest'
-          python-version: 3.9
-          environment-file: environment.yml
-          activate-environment: quantecon
+      # Install Hardware Dependant Libraries
       - name: Install Jax and Upgrade CUDA
         shell: bash -l {0}
         run: |
           pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+          pip install --upgrade "numpyro[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
           nvidia-smi
       - name: Build HTML
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     needs: deploy-runner
     runs-on: [self-hosted, cml-gpu]
     container:
-      image: docker://mmcky/quantecon-lecture-python:main
+      image: docker://mmcky/quantecon-lecture-python:py39-anaconda-2022-10
       options: --gpus all
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,15 +30,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Setup Anaconda
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          auto-activate-base: true
-          miniconda-version: 'latest'
-          python-version: 3.9
-          environment-file: environment.yml
-          activate-environment: quantecon
       - name: Install Jax and Upgrade CUDA
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
           name: execution-reports
           path: _build/html/reports
       - name: Preview Deploy to Netlify
-        uses: nwtgck/actions-netlify@v1.1
+        uses: nwtgck/actions-netlify@v2
         with:
           publish-dir: '_build/html/'
           production-branch: main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     needs: deploy-runner
     runs-on: [self-hosted, cml-gpu]
     container:
-      image: docker://nvidia/cuda:11.2.1-devel-ubuntu20.04
+      image: docker://mmcky/quantecon-lecture-python:main
       options: --gpus all
     steps:
       - uses: actions/checkout@v3
@@ -44,20 +44,6 @@ jobs:
         run: |
           pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
           nvidia-smi
-      - name: Install latex dependencies
-        shell: bash -l {0}
-        run: |
-          apt-get -qq update
-          export DEBIAN_FRONTEND=noninteractive
-          apt-get install -y tzdata
-          apt-get install -y     \
-            texlive-latex-recommended \
-            texlive-latex-extra       \
-            texlive-fonts-recommended \
-            texlive-fonts-extra       \
-            texlive-xetex             \
-            latexmk                   \
-            xindy
       - name: Display Conda Environment Versions
         shell: bash -l {0}
         run: conda list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,37 +30,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      # Install LaTeX (Support for matplotlib and PDF builds)
-      - name: Install latex dependencies
-        shell: bash -l {0}
-        run: |
-          apt-get -qq update
-          export DEBIAN_FRONTEND=noninteractive
-          apt-get install -y tzdata
-          apt-get install -y     \
-            texlive-latex-recommended \
-            texlive-latex-extra       \
-            texlive-fonts-recommended \
-            texlive-fonts-extra       \
-            texlive-xetex             \
-            latexmk                   \
-            xindy                     \
-            dvipng                    \
-            ghostscript               \
-            cm-super
-      - name: Setup Anaconda
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          auto-activate-base: true
-          miniconda-version: 'latest'
-          python-version: 3.9
-          environment-file: environment.yml
-          activate-environment: quantecon
       - name: Install Jax and Upgrade CUDA
         shell: bash -l {0}
         run: |
           pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+          pip install --upgrade "numpyro[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
           nvidia-smi
       - name: Display Conda Environment Versions
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      # Install Hardware Dependant Libraries
       - name: Install Jax and Upgrade CUDA
         shell: bash -l {0}
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,42 +28,17 @@ jobs:
     needs: deploy-runner
     runs-on: [self-hosted, cml-gpu]
     container:
-      image: docker://nvidia/cuda:11.2.1-devel-ubuntu20.04
+      image: docker://mmcky/quantecon-lecture-python:py39-anaconda-2022-10
       options: --gpus all
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      # Install LaTeX (Support for matplotlib and PDF builds)
-      - name: Install latex dependencies
-        shell: bash -l {0}
-        run: |
-          apt-get -qq update
-          export DEBIAN_FRONTEND=noninteractive
-          apt-get install -y tzdata
-          apt-get install -y     \
-            texlive-latex-recommended \
-            texlive-latex-extra       \
-            texlive-fonts-recommended \
-            texlive-fonts-extra       \
-            texlive-xetex             \
-            latexmk                   \
-            xindy                     \
-            dvipng                    \
-            ghostscript               \
-            cm-super
-      - name: Setup Anaconda
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          auto-activate-base: true
-          miniconda-version: 'latest'
-          python-version: 3.9
-          environment-file: environment.yml
-          activate-environment: quantecon
+      # Install Hardware Dependant Libraries
       - name: Install Jax and Upgrade CUDA
         shell: bash -l {0}
         run: |
           pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+          pip install --upgrade "numpyro[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
           nvidia-smi
       - name: Display Conda Environment Versions
         shell: bash -l {0}

--- a/lectures/matplotlib.md
+++ b/lectures/matplotlib.md
@@ -73,6 +73,10 @@ plt.plot(x, y, 'b-', linewidth=2)
 plt.show()
 ```
 
+```{code-cell} ipython
+print("Hi")
+```
+
 This is simple and convenient, but also somewhat limited and un-Pythonic.
 
 For example, in the function calls, a lot of objects get created and passed around without making themselves known to the programmer.

--- a/lectures/matplotlib.md
+++ b/lectures/matplotlib.md
@@ -73,10 +73,6 @@ plt.plot(x, y, 'b-', linewidth=2)
 plt.show()
 ```
 
-```{code-cell} ipython
-print("Hi")
-```
-
 This is simple and convenient, but also somewhat limited and un-Pythonic.
 
 For example, in the function calls, a lot of objects get created and passed around without making themselves known to the programmer.


### PR DESCRIPTION
This PR migrates to the custom `quantecon` docker container to:

- [x] reduce build times
- [x] reduce `ec2` costs

**Notes:** Seems the `hub.docker` has relatively slow retrieval times so may want to host container on GitHub. 

- [x] update container to include `anaconda` and then tag each docker release by the anaconda release to remove another 3min of setup time. 