### PR TITLE
ENH: Upgrade to jupyter-book==0.15.1 + Associated Packages

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -27,7 +27,7 @@ jobs:
     needs: deploy-runner
     runs-on: [self-hosted, cml-gpu]
     container:
-      image: docker://mmcky/quantecon-lecture-python:py39-anaconda-2022-10
+      image: docker://mmcky/quantecon-lecture-python:py39-anaconda-2022-10-jb-0.15.1
       options: --gpus all
     steps:
       - uses: actions/checkout@v3
@@ -37,7 +37,7 @@ jobs:
       - name: Install Jax and Upgrade CUDA
         shell: bash -l {0}
         run: |
-          pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+          pip install --upgrade "jax[cuda]==0.4.2" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
           pip install --upgrade "numpyro[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
           nvidia-smi
       - name: Build HTML

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     needs: deploy-runner
     runs-on: [self-hosted, cml-gpu]
     container:
-      image: docker://mmcky/quantecon-lecture-python:py39-anaconda-2022-10
+      image: docker://mmcky/quantecon-lecture-python:py39-anaconda-2022-10-jb-0.15.1
       options: --gpus all
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Jax and Upgrade CUDA
         shell: bash -l {0}
         run: |
-          pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+          pip install --upgrade "jax[cuda]==0.4.2" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
           pip install --upgrade "numpyro[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
           nvidia-smi
       - name: Display Conda Environment Versions

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
     needs: deploy-runner
     runs-on: [self-hosted, cml-gpu]
     container:
-      image: docker://mmcky/quantecon-lecture-python:py39-anaconda-2022-10
+      image: docker://mmcky/quantecon-lecture-python:py39-anaconda-2022-10-jb-0.15.1
       options: --gpus all
     steps:
       - name: Checkout
@@ -37,7 +37,7 @@ jobs:
       - name: Install Jax and Upgrade CUDA
         shell: bash -l {0}
         run: |
-          pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+          pip install --upgrade "jax[cuda]==0.4.2" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
           pip install --upgrade "numpyro[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
           nvidia-smi
       - name: Display Conda Environment Versions

--- a/environment.yml
+++ b/environment.yml
@@ -6,8 +6,8 @@ dependencies:
   - anaconda=2022.10
   - pip
   - pip:
-    - jupyter-book==0.12.3
-    - quantecon-book-theme==0.3.1
+    - jupyter-book==0.15.1
+    - quantecon-book-theme==0.4.0
     - sphinx-tojupyter==0.2.1
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==0.4.0

--- a/environment.yml
+++ b/environment.yml
@@ -7,19 +7,17 @@ dependencies:
   - pip
   - pip:
     - jupyter-book==0.15.1
-    - quantecon-book-theme==0.4.0
-    - sphinx-tojupyter==0.2.1
+    - quantecon-book-theme==0.4.1
+    - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
-    - sphinx-exercise==0.4.0
+    - sphinx-exercise==0.4.1
     - ghp-import==1.1.0
     - sphinxcontrib-youtube==1.1.0
     - sphinx-togglebutton==0.3.1
-    - quantecon
+    # Docker Requirements
+    - pytz
+    # Additional Requirements
     - array-to-latex
     - prettytable
-    # Sandpit Requirements
-    # - PuLP
-    # - cvxpy
-    # - cvxopt
-    # - cylp
+
 

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -2,11 +2,12 @@ title: Python Programming for Economics and Finance
 author: Thomas J. Sargent & John Stachurski
 logo: _static/qe-logo.png
 description: This website presents a set of lectures on python programming for economics, designed and written by Thomas J. Sargent and John Stachurski.
+analytics:
+  google_analytics_id: UA-54984338-9
 
 execute:
   execute_notebooks: "cache"
   timeout: 600 # 10 minutes
-#   run_in_temp: true
 
 html:
   baseurl: https://python.quantecon.org/
@@ -31,13 +32,12 @@ sphinx:
       og_logo_url: https://assets.quantecon.org/img/qe-og-logo.png
       description: This website presents a set of lectures on python programming for economics, designed and written by Thomas J. Sargent and John Stachurski.
       keywords: Python, QuantEcon, Quantitative Economics, Economics, Sloan, Alfred P. Sloan Foundation, Tom J. Sargent, John Stachurski
-      google_analytics_id: UA-54984338-9
       launch_buttons:
         notebook_interface        : classic  # The interface interactive links will activate ["classic", "jupyterlab"]
         binderhub_url             : https://mybinder.org  # The URL of the BinderHub (e.g., https://mybinder.org)
         colab_url                 : https://colab.research.google.com
         thebe                     : false  # Add a thebe button to pages (requires the repository to run on Binder)
-    mathjax_path: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-svg.js
+    mathjax_path: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
     rediraffe_redirects:
       index_toc.md: intro.md
     tojupyter_static_file_path: ["source/_static", "_static"]


### PR DESCRIPTION
This PR upgrades to `jupyter-book==0.15.1` + associated packages

This is using `anaconda==2022.10`

replaces #241 

- [x] update `quantecon` docker container with latest software
- [x] update `cache` and `publish` workflows