### PR TITLE
ENH: Upgrade anaconda==2023.03 + CUDA 12.1

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -27,18 +27,16 @@ jobs:
     needs: deploy-runner
     runs-on: [self-hosted, cml-gpu]
     container:
-      image: docker://mmcky/quantecon-lecture-python:py39-anaconda-2022-10-jb-0.15.1
+      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-03-py310
       options: --gpus all
     steps:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       # Install Hardware Dependant Libraries
-      - name: Install Jax and Upgrade CUDA
+      - name: Check nvidia drivers
         shell: bash -l {0}
         run: |
-          pip install --upgrade "jax[cuda]==0.4.2" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-          pip install --upgrade "numpyro[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
           nvidia-smi
       - name: Build HTML
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      - name: Download "build" folder (cache)
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: cache.yml
-          branch: main
-          name: build-cache
-          path: _build
+      # - name: Download "build" folder (cache)
+      #   uses: dawidd6/action-download-artifact@v2
+      #   with:
+      #     workflow: cache.yml
+      #     branch: main
+      #     name: build-cache
+      #     path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build Download Notebooks (sphinx-tojupyter)
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,18 +24,16 @@ jobs:
     needs: deploy-runner
     runs-on: [self-hosted, cml-gpu]
     container:
-      image: docker://mmcky/quantecon-lecture-python:py39-anaconda-2022-10-jb-0.15.1
+      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-03-py310
       options: --gpus all
     steps:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       # Install Hardware Dependant Libraries
-      - name: Install Jax and Upgrade CUDA
+      - name: Check nvidia drivers
         shell: bash -l {0}
         run: |
-          pip install --upgrade "jax[cuda]==0.4.2" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-          pip install --upgrade "numpyro[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
           nvidia-smi
       - name: Display Conda Environment Versions
         shell: bash -l {0}

--- a/.github/workflows/execution-linux.yml
+++ b/.github/workflows/execution-linux.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.9"]
+        python-version: ["3.10"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/execution-osx.yml
+++ b/.github/workflows/execution-osx.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["macos-latest"]
-        python-version: ["3.9"]
+        python-version: ["3.10"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/execution-win.yml
+++ b/.github/workflows/execution-win.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["windows-latest"]
-        python-version: ["3.9"]
+        python-version: ["3.10"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -23,7 +23,7 @@ jobs:
           auto-update-conda: true
           auto-activate-base: true
           miniconda-version: 'latest'
-          python-version: 3.10
+          python-version: "3.10"
           environment-file: environment.yml
           activate-environment: quantecon
       - name: Download "build" folder (cache)

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -23,7 +23,7 @@ jobs:
           auto-update-conda: true
           auto-activate-base: true
           miniconda-version: 'latest'
-          python-version: 3.9
+          python-version: 3.10
           environment-file: environment.yml
           activate-environment: quantecon
       - name: Download "build" folder (cache)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,17 +28,15 @@ jobs:
     needs: deploy-runner
     runs-on: [self-hosted, cml-gpu]
     container:
-      image: docker://mmcky/quantecon-lecture-python:py39-anaconda-2022-10-jb-0.15.1
+      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-03-py310
       options: --gpus all
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       # Install Hardware Dependant Libraries
-      - name: Install Jax and Upgrade CUDA
+      - name: Check nvidia drivers
         shell: bash -l {0}
         run: |
-          pip install --upgrade "jax[cuda]==0.4.2" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-          pip install --upgrade "numpyro[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
           nvidia-smi
       - name: Display Conda Environment Versions
         shell: bash -l {0}

--- a/environment.yml
+++ b/environment.yml
@@ -2,8 +2,8 @@ name: quantecon
 channels:
   - default
 dependencies:
-  - python=3.9
-  - anaconda=2022.10
+  - python=3.10
+  - anaconda=2023.03
   - pip
   - pip:
     - jupyter-book==0.15.1


### PR DESCRIPTION
This PR

- updates `anaconda==2023.03`
- uses `cuda 12.1` with `jaxlib==0.4.8`