### PR TITLE
[python_by_example] Remove the unnecessary text for matplotlib inline

### DIFF
--- a/lectures/python_by_example.md
+++ b/lectures/python_by_example.md
@@ -56,13 +56,6 @@ vertical axis.)
 We'll do this in several different ways, each time learning something more
 about Python.
 
-We run the following command first, which helps ensure that plots appear in the
-notebook if you run it on your own machine.
-
-```{code-cell} ipython
-%matplotlib inline
-```
-
 ## Version 1
 
 (ourfirstprog)=


### PR DESCRIPTION
Hi @jstac and @mmcky, this PR fix #271.

I've tested it in my local environment and it looks well after deleting the text.