### PR TITLE
ENH: upgrade docker to include quantecon-book-theme==0.5.0 (search)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     needs: deploy-runner
     runs-on: [self-hosted, cml-gpu]
     container:
-      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-03-py310
+      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-03-py310-b
       options: --gpus all
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR upgrades to `quantecon-book-theme==0.5.0` to incorporate search via a new Docker Container `cuda-12.1.0-anaconda-2023-03-py310-b`