### PR TITLE
ENH: Update to quantecon-book-theme==0.6.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip:
     - jupyter-book==0.15.1
     - docutils==0.17.1
-    - quantecon-book-theme==0.6.0
+    - quantecon-book-theme==0.6.1
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==0.4.1


### PR DESCRIPTION
This PR updates to `0.6.1`

https://github.com/QuantEcon/quantecon-book-theme/releases/tag/v0.6.1