### PR TITLE
ENH: Upgrade quantecon-book-theme==0.7.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip:
     - jupyter-book==0.15.1
     - docutils==0.17.1
-    - quantecon-book-theme==0.6.2
+    - quantecon-book-theme==0.7.0
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==0.4.1

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -1,5 +1,5 @@
 title: Python Programming for Economics and Finance
-author: Thomas J. Sargent & John Stachurski
+author: Thomas J. Sargent and John Stachurski
 logo: _static/qe-logo.png
 description: This website presents a set of lectures on python programming for economics, designed and written by Thomas J. Sargent and John Stachurski.
 
@@ -27,6 +27,11 @@ sphinx:
     html_theme: quantecon_book_theme
     html_static_path: ['_static']
     html_theme_options:
+      authors:  
+        - name: Thomas J. Sargent
+          url: http://www.tomsargent.com/
+        - name: John Stachurski
+          url: https://johnstachurski.net/
       dark_logo: quantecon-logo-transparent.png
       header_organisation_url: https://quantecon.org
       header_organisation: QuantEcon


### PR DESCRIPTION
This PR upgrades `quantecon-book-theme==0.7.0` which gives us:

1. author control on main page (including links)
2. newly enabled `margin` notes support