### PR TITLE
MAINT: remove %matplotlib inline and contents directives

### DIFF
--- a/lectures/about_py.md
+++ b/lectures/about_py.md
@@ -23,10 +23,6 @@ kernelspec:
 
 # About Python
 
-```{contents} Contents
-:depth: 2
-```
-
 ```{epigraph}
 "Python has gotten sufficiently weapons grade that we don’t descend into R
 anymore. Sorry, R people. I used to be one of you but we no longer descend
@@ -255,10 +251,8 @@ Its features include, among many other things:
 Here's some example code that generates and plots a random graph, with node color determined by the shortest path length from a central node.
 
 ```{code-cell} ipython
-%matplotlib inline
 import networkx as nx
 import matplotlib.pyplot as plt
-plt.rcParams['figure.figsize'] = (10,6)
 np.random.seed(1234)
 
 # Generate a random graph

--- a/lectures/debugging.md
+++ b/lectures/debugging.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: Debugging
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 ```{epigraph}
 "Debugging is twice as hard as writing the code in the first place.
 Therefore, if you write the code as cleverly as possible, you are, by definition,
@@ -61,10 +57,8 @@ Here we'll focus on Jupyter Notebook and leave you to explore other settings.
 We'll need the following imports
 
 ```{code-cell} ipython
-%matplotlib inline
 import numpy as np
 import matplotlib.pyplot as plt
-plt.rcParams['figure.figsize'] = (10,6)
 ```
 
 (debug_magic)= 

--- a/lectures/functions.md
+++ b/lectures/functions.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: Python; User-defined functions
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 Functions are an extremely useful construct provided by almost all programming.

--- a/lectures/getting_started.md
+++ b/lectures/getting_started.md
@@ -18,6 +18,8 @@ kernelspec:
 </div>
 ```
 
+<!-- TODO: Review this styling -->
+
 <style>
   .auto {
     width: 70%;
@@ -33,10 +35,6 @@ kernelspec:
 # Getting Started
 
 ```{index} single: Python
-```
-
-```{contents} Contents
-:depth: 2
 ```
 
 ## Overview
@@ -278,8 +276,6 @@ On that page, you'll see the following code
 ```{code-cell} ipython
 import numpy as np
 import matplotlib.pyplot as plt
-%matplotlib inline
-plt.rcParams['figure.figsize'] = (10,6)
 
 # Fixing random state for reproducibility
 np.random.seed(19680801)

--- a/lectures/matplotlib.md
+++ b/lectures/matplotlib.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: Python; Matplotlib
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 We've already generated quite a few figures in these lectures using [Matplotlib](http://matplotlib.org/).
@@ -61,9 +57,7 @@ But first, let's discuss the difference.
 Here's the kind of easy example you might find in introductory treatments
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
-plt.rcParams["figure.figsize"] = (10, 6) #set default figure size
 import numpy as np
 
 x = np.linspace(0, 10, 200)

--- a/lectures/need_for_speed.md
+++ b/lectures/need_for_speed.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Python for Scientific Computing
 
-```{contents} Contents
-:depth: 2
-```
-
 ```{epigraph}
 "We should forget about small efficiencies, say about 97% of the time:
 premature optimization is the root of all evil." -- Donald Knuth
@@ -379,7 +375,6 @@ Here's a plot of $f$
 
 ```{code-cell} ipython
 import matplotlib.pyplot as plt
-%matplotlib inline
 from mpl_toolkits.mplot3d.axes3d import Axes3D
 from matplotlib import cm
 

--- a/lectures/numba.md
+++ b/lectures/numba.md
@@ -22,10 +22,6 @@ kernelspec:
 
 # Numba
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython3
@@ -40,11 +36,9 @@ versions are a {doc}`common source of errors <troubleshooting>`.
 Let's start with some imports:
 
 ```{code-cell} ipython3
-%matplotlib inline
 import numpy as np
 import quantecon as qe
 import matplotlib.pyplot as plt
-plt.rcParams['figure.figsize'] = (10,6)
 ```
 
 ## Overview

--- a/lectures/numpy.md
+++ b/lectures/numpy.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: Python; NumPy
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 ```{epigraph}
 "Let's be clear: the work of science has nothing whatever to do with consensus.  Consensus is the business of politics. Science, on the contrary, requires only one investigator who happens to be right, which means that he or she has results that are verifiable by reference to the real world. In science consensus is irrelevant. What is relevant is reproducible results." -- Michael Crichton
 ```

--- a/lectures/pandas.md
+++ b/lectures/pandas.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: Python; Pandas
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what’s in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython
@@ -69,11 +65,9 @@ Throughout the lecture, we will assume that the following imports have taken
 place
 
 ```{code-cell} ipython
-%matplotlib inline
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
-plt.rcParams["figure.figsize"] = [10,8]  # Set default figure size
 import requests
 ```
 

--- a/lectures/parallelization.md
+++ b/lectures/parallelization.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Parallelization
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython
@@ -61,11 +57,9 @@ In this lecture we discuss parallelization for scientific computing, with a focu
 Let's start with some imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import numpy as np
 import quantecon as qe
 import matplotlib.pyplot as plt
-plt.rcParams['figure.figsize'] = (10,6)
 ```
 
 ## Types of Parallelization

--- a/lectures/python_advanced_features.md
+++ b/lectures/python_advanced_features.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # More Language Features
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 With this last lecture, our advice is to **skip it on first pass**, unless you have a burning desire to read it.

--- a/lectures/python_by_example.md
+++ b/lectures/python_by_example.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: Python; Introductory Example
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 We're now ready to start learning the Python language itself.

--- a/lectures/python_essentials.md
+++ b/lectures/python_essentials.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Python Essentials
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 We have covered a lot of material quite quickly, with a focus on examples.

--- a/lectures/python_oop.md
+++ b/lectures/python_oop.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: Python; Object-Oriented Programming
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 In an {doc}`earlier lecture <oop_intro>`, we learned some foundations of object-oriented programming.
@@ -61,10 +57,8 @@ It takes a little while to get used to the syntax so we'll provide plenty of exa
 We'll use the following imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import numpy as np
 import matplotlib.pyplot as plt
-plt.rcParams['figure.figsize'] = (10,6)
 ```
 
 ## OOP Review

--- a/lectures/scipy.md
+++ b/lectures/scipy.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: Python; SciPy
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 [SciPy](http://www.scipy.org) builds on top of NumPy to provide common tools for scientific programming such as
@@ -114,10 +110,8 @@ For this, we can use `scipy.stats`, which provides all of this functionality as 
 Here's an example of usage
 
 ```{code-cell} ipython
-%matplotlib inline
 from scipy.stats import beta
 import matplotlib.pyplot as plt
-plt.rcParams['figure.figsize'] = (10,6)
 
 q = beta(5, 5)      # Beta(a, b), with a = b = 5
 obs = q.rvs(2000)   # 2000 observations

--- a/lectures/sympy.md
+++ b/lectures/sympy.md
@@ -25,10 +25,6 @@ kernelspec:
 ```{index} single: Python; SymPy
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 Unlike numerical libraries that deal with values, [SymPy](https://www.sympy.org/en/index.html) focuses on manipulating mathematical symbols and expressions directly.

--- a/lectures/troubleshooting.md
+++ b/lectures/troubleshooting.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Troubleshooting
 
-```{contents} Contents
-:depth: 2
-```
-
 This page is for readers experiencing errors when running the code from the lectures.
 
 ## Fixing Your Local Environment

--- a/lectures/workspace.md
+++ b/lectures/workspace.md
@@ -20,9 +20,6 @@ kernelspec:
 
 # Writing Longer Programs
 
-```{contents} Contents
-:depth: 2
-```
 ## Overview
 
 So far, we have explored the use of Jupyter Notebooks in writing and executing Python code. 

--- a/lectures/writing_good_code.md
+++ b/lectures/writing_good_code.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: Models; Code style
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 ```{epigraph}
 "Any fool can write code that a computer can understand. Good programmers write code that humans can understand." -- Martin Fowler
 ```
@@ -75,10 +71,8 @@ The plots will be grouped into three subfigures.
 In each subfigure, two parameters are held fixed while another varies
 
 ```{code-cell} ipython
-%matplotlib inline
 import numpy as np
 import matplotlib.pyplot as plt
-plt.rcParams['figure.figsize'] = (10,6)
 
 # Allocate memory for time series
 k = np.empty(50)


### PR DESCRIPTION
This PR

- [x] removes `%matplotlib inline` and associated `figsize` settings
- [x] removes `contents` directives as not needed
- [x] validate the preview visually (spot checking)