### PR TITLE
MAINT: upgrade latest build software versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      # - name: Download "build" folder (cache)
-      #   uses: dawidd6/action-download-artifact@v6
-      #   with:
-      #     workflow: cache.yml
-      #     branch: main
-      #     name: build-cache
-      #     path: _build
+      - name: Download "build" folder (cache)
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: cache.yml
+          branch: main
+          name: build-cache
+          path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build Download Notebooks (sphinx-tojupyter)
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      - name: Download "build" folder (cache)
-        uses: dawidd6/action-download-artifact@v6
-        with:
-          workflow: cache.yml
-          branch: main
-          name: build-cache
-          path: _build
+      # - name: Download "build" folder (cache)
+      #   uses: dawidd6/action-download-artifact@v6
+      #   with:
+      #     workflow: cache.yml
+      #     branch: main
+      #     name: build-cache
+      #     path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build Download Notebooks (sphinx-tojupyter)
         shell: bash -l {0}

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
     - git+https://github.com/QuantEcon/quantecon-book-theme@maint-22oct
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
-    - sphinx-exercise==0.4.1
+    - git+https://github.com/executablebooks/sphinx-exercise@maint-22oct
     - ghp-import==2.1.0
     - sphinxcontrib-youtube==1.4.1
     - sphinx-togglebutton==0.3.2

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - pip:
     - jupyter-book==1.0.3
-    - quantecon-book-theme==0.7.5
+    - quantecon-book-theme==0.7.6
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==1.0.1

--- a/environment.yml
+++ b/environment.yml
@@ -6,15 +6,15 @@ dependencies:
   - anaconda=2024.06
   - pip
   - pip:
-    - jupyter-book==0.15.1
-    - docutils==0.17.1
+    - jupyter-book==1.0.3
+    # - docutils==0.17.1
     - quantecon-book-theme==0.7.2
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==0.4.1
-    - ghp-import==1.1.0
-    - sphinxcontrib-youtube==1.1.0
-    - sphinx-togglebutton==0.3.1
+    - ghp-import==2.1.0
+    - sphinxcontrib-youtube==1.4.1
+    - sphinx-togglebutton==0.3.2
     # Github Actions Bug
     - requests
     # Docker Requirements

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
     - sphinxext-rediraffe==0.2.7
     - git+https://github.com/executablebooks/sphinx-exercise@main
     - ghp-import==2.1.0
-    - sphinxcontrib-youtube==1.3.0
+    - sphinxcontrib-youtube==1.4.1
     - sphinx-togglebutton==0.3.2
     # Github Actions Bug
     - requests

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip:
     - jupyter-book==1.0.3
     # - docutils==0.17.1
-    - git+https://github.com/QuantEcon/quantecon-book-theme@maint-22oct
+    - git+https://github.com/QuantEcon/quantecon-book-theme@main
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
     - git+https://github.com/executablebooks/sphinx-exercise@maint-22oct

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - pip:
     - jupyter-book==1.0.3
-    - git+https://github.com/QuantEcon/quantecon-book-theme@update-libsass-win
+    - quantecon-book-theme==0.7.5
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==1.0.1

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
     - git+https://github.com/QuantEcon/quantecon-book-theme@main
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
-    - git+https://github.com/executablebooks/sphinx-exercise@maint-22oct
+    - git+https://github.com/executablebooks/sphinx-exercise@main
     - ghp-import==2.1.0
     - sphinxcontrib-youtube==1.4.1
     - sphinx-togglebutton==0.3.2

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip:
     - jupyter-book==1.0.3
     # - docutils==0.17.1
-    - git+https://github.com/QuantEcon/quantecon-book-theme@main
+    - git+https://github.com/QuantEcon/quantecon-book-theme@fix-sphinx5
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
     - git+https://github.com/executablebooks/sphinx-exercise@main

--- a/environment.yml
+++ b/environment.yml
@@ -8,10 +8,10 @@ dependencies:
   - pip:
     - jupyter-book==1.0.3
     # - docutils==0.17.1
-    - git+https://github.com/QuantEcon/quantecon-book-theme@fix-sphinx5
+    - quantecon-book-theme==0.7.4
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
-    - git+https://github.com/executablebooks/sphinx-exercise@main
+    - sphinx-exercise==1.0.1
     - ghp-import==2.1.0
     - sphinxcontrib-youtube==1.3.0  #Version 1.3.0 is required as quantecon-book-theme is only compatible with sphinx<=5
     - sphinx-togglebutton==0.3.2

--- a/environment.yml
+++ b/environment.yml
@@ -7,20 +7,12 @@ dependencies:
   - pip
   - pip:
     - jupyter-book==1.0.3
-    # - docutils==0.17.1
-    - quantecon-book-theme==0.7.4
+    - git+https://github.com/QuantEcon/quantecon-book-theme@update-libsass-win
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==1.0.1
     - ghp-import==2.1.0
     - sphinxcontrib-youtube==1.3.0  #Version 1.3.0 is required as quantecon-book-theme is only compatible with sphinx<=5
     - sphinx-togglebutton==0.3.2
-    # Github Actions Bug
-    - requests
-    # Docker Requirements
-    - pytz
-    # Additional Requirements
-    - array-to-latex
-    - prettytable
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
     - sphinxext-rediraffe==0.2.7
     - git+https://github.com/executablebooks/sphinx-exercise@main
     - ghp-import==2.1.0
-    - sphinxcontrib-youtube==1.4.1
+    - sphinxcontrib-youtube==1.3.0  #Version 1.3.0 is required as quantecon-book-theme is only compatible with sphinx<=5
     - sphinx-togglebutton==0.3.2
     # Github Actions Bug
     - requests

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip:
     - jupyter-book==1.0.3
     # - docutils==0.17.1
-    - quantecon-book-theme==0.7.2
+    - git+https://github.com/QuantEcon/quantecon-book-theme@maint-22oct
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==0.4.1

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
     - sphinxext-rediraffe==0.2.7
     - git+https://github.com/executablebooks/sphinx-exercise@main
     - ghp-import==2.1.0
-    - sphinxcontrib-youtube==1.4.1
+    - sphinxcontrib-youtube==1.3.0
     - sphinx-togglebutton==0.3.2
     # Github Actions Bug
     - requests


### PR DESCRIPTION
This upgrades the software to the latest versions of `jupyter-book` including updates to `quantecon-book-theme` and `sphinx-exercise` for compatibility. 

- [x] release `quantecon-book-theme==0.7.5` once bugs fixed
- [x] release `sphinx-exercise==1.0.1` once bugs fixed
- [x] review preview to check outputs using latest `jupyter-book==1.0.3`