### PR TITLE
FIX: enable .jupyter_cache to be included in cache runs

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -32,3 +32,4 @@ jobs:
         with:
           name: build-cache
           path: _build
+          include-hidden-files: true


### PR DESCRIPTION
This PR fixes a bug that has prevented the cache mechanism to work. 

Hidden files were not included by default in the upload-artifact action

https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#hidden-files