### PR TITLE
ENH: use lychee for linkchecking

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -6,14 +6,11 @@ on:
     # UTC 12:00 is early morning in Australia
     - cron:  '0 12 * * *'
 jobs:
-  execution-tests-linux:
-    name: Execution Tests (${{ matrix.python-version }}, ${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ["ubuntu-latest"]
-        python-version: ["3.12"]
+  link-checking:
+    name: Link Checking
+    runs-on: "ubunut-latest"
+    permissions:
+        issues: write # required for peter-evans/create-issue-from-file
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -22,6 +19,13 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: --accept 403 lectures/*.md
+      - name: Create Issue From File
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue
       # - name: Setup Anaconda
       #   uses: conda-incubator/setup-miniconda@v3
       #   with:

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -17,28 +17,34 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Anaconda
-        uses: conda-incubator/setup-miniconda@v3
-        with:
-          auto-update-conda: true
-          auto-activate-base: true
-          miniconda-version: 'latest'
-          python-version: "3.12"
-          environment-file: environment.yml
-          activate-environment: quantecon
-      - name: Download "build" folder (cache)
-        uses: dawidd6/action-download-artifact@v10
-        with:
-          workflow: cache.yml
-          branch: main
-          name: build-cache
-          path: _build
       - name: Link Checker
-        shell: bash -l {0}
-        run: jb build lectures --path-output=./ --builder=custom --custom-builder=linkcheck
-      - name: Upload Link Checker Reports
-        uses: actions/upload-artifact@v4
-        if: failure()
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
         with:
-          name: linkcheck-reports
-          path: _build/linkcheck
+          args: --accept 403
+          workingDirectory: lectures
+      # - name: Setup Anaconda
+      #   uses: conda-incubator/setup-miniconda@v3
+      #   with:
+      #     auto-update-conda: true
+      #     auto-activate-base: true
+      #     miniconda-version: 'latest'
+      #     python-version: "3.12"
+      #     environment-file: environment.yml
+      #     activate-environment: quantecon
+      # - name: Download "build" folder (cache)
+      #   uses: dawidd6/action-download-artifact@v10
+      #   with:
+      #     workflow: cache.yml
+      #     branch: main
+      #     name: build-cache
+      #     path: _build
+      # - name: Link Checker
+      #   shell: bash -l {0}
+      #   run: jb build lectures --path-output=./ --builder=custom --custom-builder=linkcheck
+      # - name: Upload Link Checker Reports
+      #   uses: actions/upload-artifact@v4
+      #   if: failure()
+      #   with:
+      #     name: linkcheck-reports
+      #     path: _build/linkcheck

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -22,7 +22,6 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: --accept 403
-          workingDirectory: lectures/
       # - name: Setup Anaconda
       #   uses: conda-incubator/setup-miniconda@v3
       #   with:

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -10,7 +10,7 @@ jobs:
     name: Link Checking
     runs-on: "ubunut-latest"
     permissions:
-        issues: write # required for peter-evans/create-issue-from-file
+      issues: write # required for peter-evans/create-issue-from-file
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -21,7 +21,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --accept 403
+          args: --accept 403 lectures/*.md
       # - name: Setup Anaconda
       #   uses: conda-incubator/setup-miniconda@v3
       #   with:

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   link-checking:
     name: Link Checking
-    runs-on: "ubunut-latest"
+    runs-on: "ubuntu-latest"
     permissions:
       issues: write # required for peter-evans/create-issue-from-file
     steps:

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,10 +1,8 @@
 name: Link Checker [Anaconda, Linux]
 on:
-  pull_request:
-    types: [opened, reopened]
   schedule:
-    # UTC 12:00 is early morning in Australia
-    - cron:  '0 12 * * *'
+    # UTC 23:00 is early morning in Australia (9am)
+    - cron:  '0 23 * * *'
 jobs:
   link-checking:
     name: Link Checking
@@ -12,50 +10,21 @@ jobs:
     permissions:
       issues: write # required for peter-evans/create-issue-from-file
     steps:
+      # Checkout the live site (html)
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Download "build" folder (cache)
-        uses: dawidd6/action-download-artifact@v10
         with:
-          workflow: cache.yml
-          branch: main
-          name: build-cache
-          path: _build
+          ref: gh-pages
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
           fail: false
-          args: --accept 403 lectures/*.md
+          args: --accept 403 .
       - name: Create Issue From File
         if: steps.lychee.outputs.exit_code != 0
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md
-          labels: report, automated issue
-      # - name: Setup Anaconda
-      #   uses: conda-incubator/setup-miniconda@v3
-      #   with:
-      #     auto-update-conda: true
-      #     auto-activate-base: true
-      #     miniconda-version: 'latest'
-      #     python-version: "3.12"
-      #     environment-file: environment.yml
-      #     activate-environment: quantecon
-      # - name: Download "build" folder (cache)
-      #   uses: dawidd6/action-download-artifact@v10
-      #   with:
-      #     workflow: cache.yml
-      #     branch: main
-      #     name: build-cache
-      #     path: _build
-      # - name: Link Checker
-      #   shell: bash -l {0}
-      #   run: jb build lectures --path-output=./ --builder=custom --custom-builder=linkcheck
-      # - name: Upload Link Checker Reports
-      #   uses: actions/upload-artifact@v4
-      #   if: failure()
-      #   with:
-      #     name: linkcheck-reports
-      #     path: _build/linkcheck
+          labels: report, automated issue, linkchecker

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -18,6 +18,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
+          fail: false
           args: --accept 403 lectures/*.md
       - name: Create Issue From File
         if: steps.lychee.outputs.exit_code != 0

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -14,6 +14,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Download "build" folder (cache)
+        uses: dawidd6/action-download-artifact@v10
+        with:
+          workflow: cache.yml
+          branch: main
+          name: build-cache
+          path: _build
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v2

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -22,7 +22,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: --accept 403
-          workingDirectory: lectures
+          workingDirectory: lectures/
       # - name: Setup Anaconda
       #   uses: conda-incubator/setup-miniconda@v3
       #   with:

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -8,7 +8,7 @@ execute:
   timeout: 600 # 10 minutes
 
 html:
-  baseurl: https://python.quantecon.org/
+  baseurl: https://python-programming.quantecon.org/
 
 latex:
   latex_documents:


### PR DESCRIPTION
This PR sets up [lychee](https://github.com/lycheeverse/lychee) for more robust link checking and:

1. removes link-checking from the PR process (as a distraction)
2. uses `lychee` as a more robust solution to parse `html`
3. checks the live site `gh-pages` every day. 
4. Posts an issue with any results (excluding `403` and `503`)

Interestingly the only `503` results are all the AI company websites. They are blocking web traffic requests! Kind of ironic given how they have been trained. 

This PR also fixes the canonical site address from `python.` to `python-programming.` that is embedded in the html. 

---

Issues with checking `md` directly. 

These types of links `[lecture on broadcasting](broadcasting)` get resolved to a web address by default which produces an error. 

- [x] perhaps should use `html` parsing instead of `md` parsing to avoid some of these minor syntax issues that `Jupyter-book` resolves at build time. 