### PR TITLE
Update GitHub Actions to use new QuantEcon action locations

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           ref: gh-pages
       - name: AI-Powered Link Checker
-        uses: QuantEcon/meta/.github/actions/link-checker@main
+        uses: QuantEcon/action-link-checker@main
         with:
           html-path: '.'            # gh-pages live html
           fail-on-broken: 'false'


### PR DESCRIPTION
- Replace `QuantEcon/meta/.github/actions/link-checker@main` with `QuantEcon/action-link-checker@main` in linkcheck.yml
- This migration moves from the old meta repository structure to the new dedicated action repositories