### PR TITLE
chore: bump action-translation to v0.14.1

### DIFF
--- a/.github/workflows/sync-translations-fa.yml
+++ b/.github/workflows/sync-translations-fa.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.14.0
+      - uses: QuantEcon/action-translation@v0.14.1
         with:
           mode: sync
           target-repo: QuantEcon/lecture-python-programming.fa

--- a/.github/workflows/sync-translations-zh-cn.yml
+++ b/.github/workflows/sync-translations-zh-cn.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.14.0
+      - uses: QuantEcon/action-translation@v0.14.1
         with:
           mode: sync
           target-repo: QuantEcon/lecture-python-programming.zh-cn


### PR DESCRIPTION
Bumps `QuantEcon/action-translation` from v0.14.0 to [v0.14.1](https://github.com/QuantEcon/action-translation/releases/tag/v0.14.1) in both sync workflows (zh-cn and fa).

### Changes in v0.14.1

- **Heading-map injection for new files**: `processFull()` now injects `translation:` frontmatter for newly translated files
- **`MISSING_HEADINGMAP` false positive fix**: title-only files no longer flagged
- **Docs**: language-targeted `\\translate-resync` syntax documented